### PR TITLE
Using japi-check, build out backwards compatability based on OpenGrok searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 Failsafe is a lightweight, zero-dependency library for handling failures in Java 8+, with a concise API for handling everyday use cases and the flexibility to handle everything else. It  works by wrapping executable logic with one or more resilience policies, which can be combined and composed as needed.
 
+## HubSpot - Migration From 1.X to 2.X compatability
+[Report of incompatabilities](failsafe-1.0.3-failsafe-2.3.0.html)
+
 ## Usage
 
 Visit the [project website](https://jodah.net/failsafe).

--- a/failsafe-1.0.3-failsafe-2.3.0.html
+++ b/failsafe-1.0.3-failsafe-2.3.0.html
@@ -1,0 +1,96 @@
+<html><head><title>failsafe-1.0.3 → failsafe-2.3.0</title><style type="text/css">body {
+  font-family: Helvetica, Arial, Sans-Serif;
+  line-height: 1.5em;
+}
+
+h1 {
+  font-weight: 500;
+}
+
+h2 {
+  font-weight: 400;
+}
+
+header {
+  padding: 2px 30px 4px;
+  border-bottom: 1px solid grey;
+}
+
+main {
+  padding: 20px 30px;
+}
+
+.link {
+  font-size: 1em;
+  text-align: left;
+  color: #0091ae;
+  background: none;
+  margin: 0;
+  padding: 0;
+  border: none;
+  cursor: pointer;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+.link:focus {
+  outline: none;
+}
+
+.class {
+  margin-bottom: 20px;
+  border: 1px solid grey;
+  background-color: #FBFBFB;
+}
+
+.class-header {
+  font-size: larger;
+  padding: 10px 16px;
+  border-bottom: 1px solid grey;
+  background-color: #E8E8E8;
+}
+
+.class-name {
+  font-weight: 500;
+}
+
+.package-name {
+  color: #555;
+}
+
+.datatype-change, .method-change {
+  padding: 10px 16px;
+}
+
+.method-change:nth-child(even) {
+  background-color: #F3F3F3;
+}
+
+.method-signature {
+  font-size: 1.2em;
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+</style></head><body><header><h1>failsafe-1.0.3 → failsafe-2.3.0</h1></header><main><div>
+          <button class="link" onclick="copyMarkdownSummaryToClipboard()">
+            Copy markdown summary to clipboard
+          </button>
+        </div><h2 id="changed-data-types">Changed datatypes</h2><div><div class="class"><div class="class-header"><span class="class-name">Failsafe.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="datatype-change"><div>Parameter at index 0 to method with changed from net.jodah.failsafe.CircuitBreaker to java.util.List&lt;? extends net.jodah.failsafe.Policy&lt;R extends java.lang.Object&gt;&gt;.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">FailsafeFuture.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="datatype-change"><div>Visibility was reduced from &#x27;public&#x27; to &#x27;package&#x27;.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">Ratio.class</span><br/><small class="package-name">net.jodah.failsafe.util</small></div><div><div class="datatype-change"><div>Visibility was reduced from &#x27;public&#x27; to &#x27;private&#x27;.</div></div><div class="datatype-change"><div>Visibility was reduced from &#x27;public&#x27; to &#x27;private&#x27;.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">RetryPolicy.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="datatype-change"><div>Parameter at index 2 to method withBackoff changed from java.util.concurrent.TimeUnit to java.time.temporal.ChronoUnit.</div></div></div></div></div><h2 id="removed-data-types">Removed datatypes</h2><div><div class="class"><div class="class-header"><span class="class-name">AsyncCallable.class</span><br/><small class="package-name">net.jodah.failsafe.function</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">AsyncFailsafe.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">AsyncFailsafeConfig.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">BiPredicate.class</span><br/><small class="package-name">net.jodah.failsafe.function</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">CancellableFuture.class</span><br/><small class="package-name">net.jodah.failsafe.internal.util</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">CheckedBiConsumer.class</span><br/><small class="package-name">net.jodah.failsafe.function</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">CheckedBiFunction.class</span><br/><small class="package-name">net.jodah.failsafe.function</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">CircuitBreakerStats.class</span><br/><small class="package-name">net.jodah.failsafe.internal</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">ContextualCallable.class</span><br/><small class="package-name">net.jodah.failsafe.function</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">ContextualResultListener.class</span><br/><small class="package-name">net.jodah.failsafe.event</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">Duration.class</span><br/><small class="package-name">net.jodah.failsafe.util</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">FailsafeConfig.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">Listeners.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">Predicate.class</span><br/><small class="package-name">net.jodah.failsafe.function</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">Ratio.class</span><br/><small class="package-name">net.jodah.failsafe.util</small></div><div><div class="datatype-change"><div>Field removed from class.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">ReentrantCircuit.class</span><br/><small class="package-name">net.jodah.failsafe.internal.util</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">Schedulers.class</span><br/><small class="package-name">net.jodah.failsafe.util.concurrent</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div><div class="class"><div class="class-header"><span class="class-name">SyncFailsafe.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="datatype-change"><div>Class was removed.</div></div></div></div></div><h2 id="changed-methods">Changed methods</h2><div><div class="class"><div class="class-header"><span class="class-name">AsyncExecution.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="method-change"><div class="method-signature"><code>getWaitTime( ) Duration</code></div><div><div>The return type changed from &#x27;net.jodah.failsafe.util.Duration&#x27; to  &#x27;java.time.Duration&#x27;.</div></div></div></div></div><div class="class"><div class="class-header"><span class="class-name">CircuitBreaker.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="method-change"><div class="method-signature"><code>getDelay( ) Duration</code></div><div><div>The return type changed from &#x27;net.jodah.failsafe.util.Duration&#x27; to  &#x27;java.time.Duration&#x27;.</div></div></div><div class="method-change"><div class="method-signature"><code>getTimeout( ) Duration</code></div><div><div>The return type changed from &#x27;net.jodah.failsafe.util.Duration&#x27; to  &#x27;java.time.Duration&#x27;.</div></div></div><div class="method-change"><div class="method-signature"><code>onClose( CheckedRunnable ) void</code></div><div><div>The return type changed from &#x27;void&#x27; to  &#x27;net.jodah.failsafe.CircuitBreaker&lt;R extends java.lang.Object&gt;&#x27;.</div></div></div><div class="method-change"><div class="method-signature"><code>onHalfOpen( CheckedRunnable ) void</code></div><div><div>The return type changed from &#x27;void&#x27; to  &#x27;net.jodah.failsafe.CircuitBreaker&lt;R extends java.lang.Object&gt;&#x27;.</div></div></div><div class="method-change"><div class="method-signature"><code>onOpen( CheckedRunnable ) void</code></div><div><div>The return type changed from &#x27;void&#x27; to  &#x27;net.jodah.failsafe.CircuitBreaker&lt;R extends java.lang.Object&gt;&#x27;.</div></div></div><div class="method-change"><div class="method-signature"><code>withDelay( long, TimeUnit ) CircuitBreaker</code></div><div><div>The number of parameters of the method have changed.</div></div></div><div class="method-change"><div class="method-signature"><code>withTimeout( long, TimeUnit ) CircuitBreaker</code></div><div><div>The number of parameters of the method have changed.</div></div></div></div></div><div class="class"><div class="class-header"><span class="class-name">CircuitBreakerOpenException.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="method-change"><div class="method-signature"><code>&lt;init&gt;( ) void</code></div><div><div>The number of parameters of the method have changed.</div></div></div></div></div><div class="class"><div class="class-header"><span class="class-name">CircuitState.class</span><br/><small class="package-name">net.jodah.failsafe.internal</small></div><div><div class="method-change"><div class="method-signature"><code>allowsExecution( CircuitBreakerStats ) boolean</code></div><div><div>The number of parameters of the method have changed.</div></div></div><div class="method-change"><div class="method-signature"><code>getInternals( ) CircuitBreaker.State</code></div><div><div>Abstract method was added.</div></div></div><div class="method-change"><div class="method-signature"><code>recordFailure( ) void</code></div><div><div>The number of parameters of the method have changed.</div></div></div></div></div><div class="class"><div class="class-header"><span class="class-name">CircularBitSet.class</span><br/><small class="package-name">net.jodah.failsafe.internal.util</small></div><div><div class="method-change"><div class="method-signature"><code>negativeRatio( ) double</code></div><div><div>The return type changed from &#x27;double&#x27; to  &#x27;net.jodah.failsafe.util.Ratio&#x27;.</div></div></div><div class="method-change"><div class="method-signature"><code>positiveRatio( ) double</code></div><div><div>The return type changed from &#x27;double&#x27; to  &#x27;net.jodah.failsafe.util.Ratio&#x27;.</div></div></div></div></div><div class="class"><div class="class-header"><span class="class-name">Execution.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="method-change"><div class="method-signature"><code>&lt;init&gt;( CircuitBreaker ) void</code></div><div><div>Visibility reduced from public to package.</div></div></div></div></div><div class="class"><div class="class-header"><span class="class-name">ExecutionContext.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="method-change"><div class="method-signature"><code>getElapsedTime( ) Duration</code></div><div><div>The return type changed from &#x27;net.jodah.failsafe.util.Duration&#x27; to  &#x27;java.time.Duration&#x27;.</div></div></div><div class="method-change"><div class="method-signature"><code>getStartTime( ) Duration</code></div><div><div>The return type changed from &#x27;net.jodah.failsafe.util.Duration&#x27; to  &#x27;java.time.Duration&#x27;.</div></div></div></div></div><div class="class"><div class="class-header"><span class="class-name">Failsafe.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="method-change"><div class="method-signature"><code>with( CircuitBreaker ) SyncFailsafe&lt;T&gt;</code></div><div><div>The return type changed from &#x27;net.jodah.failsafe.SyncFailsafe&lt;T extends java.lang.Object&gt;&#x27; to  &#x27;net.jodah.failsafe.FailsafeExecutor&lt;R extends java.lang.Object&gt;&#x27;.</div></div></div><div class="method-change"><div class="method-signature"><code>with( RetryPolicy ) SyncFailsafe&lt;T&gt;</code></div><div><div>The return type changed from &#x27;net.jodah.failsafe.SyncFailsafe&lt;T extends java.lang.Object&gt;&#x27; to  &#x27;net.jodah.failsafe.FailsafeExecutor&lt;R extends java.lang.Object&gt;&#x27;.</div></div></div></div></div><div class="class"><div class="class-header"><span class="class-name">RetryPolicy.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="method-change"><div class="method-signature"><code>getJitter( ) Duration</code></div><div><div>The return type changed from &#x27;net.jodah.failsafe.util.Duration&#x27; to  &#x27;java.time.Duration&#x27;.</div></div></div><div class="method-change"><div class="method-signature"><code>getMaxDelay( ) Duration</code></div><div><div>The return type changed from &#x27;net.jodah.failsafe.util.Duration&#x27; to  &#x27;java.time.Duration&#x27;.</div></div></div><div class="method-change"><div class="method-signature"><code>getMaxDuration( ) Duration</code></div><div><div>The return type changed from &#x27;net.jodah.failsafe.util.Duration&#x27; to  &#x27;java.time.Duration&#x27;.</div></div></div><div class="method-change"><div class="method-signature"><code>withJitter( long, TimeUnit ) RetryPolicy</code></div><div><div>The number of parameters of the method have changed.</div></div></div><div class="method-change"><div class="method-signature"><code>withMaxDuration( long, TimeUnit ) RetryPolicy</code></div><div><div>The number of parameters of the method have changed.</div></div></div></div></div></div><h2 id="removed-methods">Removed methods</h2><div><div class="class"><div class="class-header"><span class="class-name">CircuitBreaker.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="method-change"><div class="method-signature"><code>failIf( BiPredicate&lt;T, ? extends Throwable&gt; ) CircuitBreaker</code></div><div><div>Method was removed.</div></div></div><div class="method-change"><div class="method-signature"><code>failIf( Predicate&lt;T&gt; ) CircuitBreaker</code></div><div><div>Method was removed.</div></div></div><div class="method-change"><div class="method-signature"><code>failOn( Class&lt;? extends Throwable&gt;[] ) CircuitBreaker</code></div><div><div>Method was removed.</div></div></div><div class="method-change"><div class="method-signature"><code>failOn( List&lt;Class&lt;? extends Throwable&gt;&gt; ) CircuitBreaker</code></div><div><div>Method was removed.</div></div></div><div class="method-change"><div class="method-signature"><code>failOn( Predicate&lt;? extends Throwable&gt; ) CircuitBreaker</code></div><div><div>Method was removed.</div></div></div><div class="method-change"><div class="method-signature"><code>failWhen( Object ) CircuitBreaker</code></div><div><div>Method was removed.</div></div></div></div></div><div class="class"><div class="class-header"><span class="class-name">CircuitState.class</span><br/><small class="package-name">net.jodah.failsafe.internal</small></div><div><div class="method-change"><div class="method-signature"><code>getState( ) CircuitBreaker.State</code></div><div><div>Method was removed.</div></div></div></div></div><div class="class"><div class="class-header"><span class="class-name">Execution.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="method-change"><div class="method-signature"><code>&lt;init&gt;( RetryPolicy ) void</code></div><div><div>Method was removed.</div></div></div><div class="method-change"><div class="method-signature"><code>&lt;init&gt;( RetryPolicy, CircuitBreaker ) void</code></div><div><div>Method was removed.</div></div></div></div></div><div class="class"><div class="class-header"><span class="class-name">ExecutionContext.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="method-change"><div class="method-signature"><code>getExecutions( ) int</code></div><div><div>Method was removed.</div></div></div></div></div><div class="class"><div class="class-header"><span class="class-name">RetryPolicy.class</span><br/><small class="package-name">net.jodah.failsafe</small></div><div><div class="method-change"><div class="method-signature"><code>canAbortFor( Object, Throwable ) boolean</code></div><div><div>Method was removed.</div></div></div><div class="method-change"><div class="method-signature"><code>canRetryFor( Object, Throwable ) boolean</code></div><div><div>Method was removed.</div></div></div><div class="method-change"><div class="method-signature"><code>retryIf( BiPredicate&lt;T, ? extends Throwable&gt; ) RetryPolicy</code></div><div><div>Method was removed.</div></div></div><div class="method-change"><div class="method-signature"><code>retryIf( Predicate&lt;T&gt; ) RetryPolicy</code></div><div><div>Method was removed.</div></div></div><div class="method-change"><div class="method-signature"><code>retryOn( Class&lt;? extends Throwable&gt;[] ) RetryPolicy</code></div><div><div>Method was removed.</div></div></div><div class="method-change"><div class="method-signature"><code>retryOn( List&lt;Class&lt;? extends Throwable&gt;&gt; ) RetryPolicy</code></div><div><div>Method was removed.</div></div></div><div class="method-change"><div class="method-signature"><code>retryOn( Predicate&lt;? extends Throwable&gt; ) RetryPolicy</code></div><div><div>Method was removed.</div></div></div><div class="method-change"><div class="method-signature"><code>retryWhen( Object ) RetryPolicy</code></div><div><div>Method was removed.</div></div></div></div></div></div></main><script>
+        function copyMarkdownSummaryToClipboard() {
+          (text => {
+  const textarea = document.createElement('textarea');
+  document.body.appendChild(textarea);
+  textarea.value = text;
+  textarea.select();
+  try {
+    const success = document.execCommand('copy');
+    console.log(success ? 'Copied to clipboard' : 'Copy to clipboard failed');
+  } catch (e) {
+    console.log('Copy to clipboard failed', e);
+  }
+  document.body.removeChild(textarea);
+})("## failsafe-1.0.3 → failsafe-2.3.0\n\n| Type | Count |\n| - | -: |\n| Changed datatypes | 5 |\n| Changed methods | 24 |\n| Removed datatypes | 18 |\n| Removed methods | 18 |\n");
+        };
+      </script></body></html>

--- a/src/main/java/net/jodah/failsafe/CircuitBreaker.java
+++ b/src/main/java/net/jodah/failsafe/CircuitBreaker.java
@@ -238,6 +238,33 @@ public class CircuitBreaker<R> extends DelayablePolicy<CircuitBreaker<R>, R> {
   }
 
   /**
+   * Calls the {@code runnable} when the circuit is closed.
+   * <p>Note: Any exceptions that are thrown from within the {@code runnable} are ignored.</p>
+   */
+  /* Alias for dealing with runtime error on binary incompatibility change of the onClose signature by manually swapping off the affected method name during the migration */
+  public void onCloseMigration(CheckedRunnable runnable) {
+    onClose = runnable;
+  }
+
+  /**
+   * Calls the {@code runnable} when the circuit is half-opened.
+   * <p>Note: Any exceptions that are thrown within the {@code runnable} are ignored.</p>
+   */
+  /* Alias for dealing with runtime error on binary incompatibility change of the onHalfOpen signature by manually swapping off the affected method name during the migration */
+  public void onHalfOpenMigration(CheckedRunnable runnable) {
+    onHalfOpen = runnable;
+  }
+
+  /**
+   * Calls the {@code runnable} when the circuit is opened.
+   * <p>Note: Any exceptions that are thrown within the {@code runnable} are ignored.</p>
+   */
+  /* Alias for dealing with runtime error on binary incompatibility change of the onOpen signature by manually swapping off the affected method name during the migration */
+  public void onOpenMigration(CheckedRunnable runnable) {
+    onOpen = runnable;
+  }
+
+  /**
    * Opens the circuit.
    */
   public void open() {

--- a/src/main/java/net/jodah/failsafe/CircuitBreakerOpenException.java
+++ b/src/main/java/net/jodah/failsafe/CircuitBreakerOpenException.java
@@ -29,6 +29,12 @@ public class CircuitBreakerOpenException extends FailsafeException {
     this.circuitBreaker = circuitBreaker;
   }
 
+  /* Backwards compatability for 1.x -> 2.x migration */
+  @Deprecated
+  public CircuitBreakerOpenException() {
+    this.circuitBreaker = null;
+  }
+
   /** Retruns the {@link CircuitBreaker} that caused the exception. */
   public CircuitBreaker getCircuitBreaker() {
     return circuitBreaker;

--- a/src/main/java/net/jodah/failsafe/Failsafe.java
+++ b/src/main/java/net/jodah/failsafe/Failsafe.java
@@ -18,6 +18,7 @@ package net.jodah.failsafe;
 import net.jodah.failsafe.internal.util.Assert;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**

--- a/src/main/java/net/jodah/failsafe/FailurePolicy.java
+++ b/src/main/java/net/jodah/failsafe/FailurePolicy.java
@@ -15,14 +15,14 @@
  */
 package net.jodah.failsafe;
 
-import net.jodah.failsafe.internal.util.Assert;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
+
+import net.jodah.failsafe.internal.util.Assert;
 
 /**
  * A Policy that captures conditions to determine whether an execution is a failure.
@@ -54,6 +54,18 @@ public abstract class FailurePolicy<S, R> extends PolicyListeners<S, R> implemen
     return handle(Arrays.asList(failure));
   }
 
+  /* Backwards compatability for 1.x -> 2.x migration. Use `handle` */
+  @Deprecated
+  public S failOn(Class<? extends Throwable> failure) {
+    return handle(failure);
+  }
+
+  /* Backwards compatability for 1.x -> 2.x migration. Use `handle` */
+  @Deprecated
+  public S retryOn(Class<? extends Throwable> failure) {
+    return handle(failure);
+  }
+
   /**
    * Specifies the failures to handle. Any failures that are assignable from the {@code failures} will be handled.
    *
@@ -65,6 +77,18 @@ public abstract class FailurePolicy<S, R> extends PolicyListeners<S, R> implemen
     Assert.notNull(failures, "failures");
     Assert.isTrue(failures.length > 0, "Failures cannot be empty");
     return handle(Arrays.asList(failures));
+  }
+
+  /* Backwards compatability for 1.x -> 2.x migration. Use `handle` */
+  @Deprecated
+  public final S failOn(Class<? extends Throwable>... failures) {
+    return handle(failures);
+  }
+
+  /* Backwards compatability for 1.x -> 2.x migration. Use `handle` */
+  @Deprecated
+  public final S retryOn(Class<? extends Throwable>... failures) {
+    return handle(failures);
   }
 
   /**
@@ -93,6 +117,18 @@ public abstract class FailurePolicy<S, R> extends PolicyListeners<S, R> implemen
     return (S) this;
   }
 
+  /* Backwards compatability for 1.x -> 2.x migration. Use `handleIf` */
+  @Deprecated
+  public S failIf(Predicate<? extends Throwable> failurePredicate) {
+    return handleIf(failurePredicate);
+  }
+
+  /* Backwards compatability for 1.x -> 2.x migration. Use `handleIf` */
+  @Deprecated
+  public S retryIf(Predicate<? extends Throwable> failurePredicate) {
+    return handleIf(failurePredicate);
+  }
+
   /**
    * Specifies that a failure has occurred if the {@code resultPredicate} matches the execution result.
    *
@@ -104,6 +140,12 @@ public abstract class FailurePolicy<S, R> extends PolicyListeners<S, R> implemen
     failuresChecked = true;
     failureConditions.add((BiPredicate<R, Throwable>) resultPredicate);
     return (S) this;
+  }
+
+  /* Backwards compatability for 1.x -> 2.x migration. Use `handleIf` */
+  @Deprecated
+  public S failIf(BiPredicate<R, ? extends Throwable> resultPredicate) {
+    return handleIf(resultPredicate);
   }
 
   /**

--- a/src/main/java/net/jodah/failsafe/RetryPolicy.java
+++ b/src/main/java/net/jodah/failsafe/RetryPolicy.java
@@ -26,6 +26,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
@@ -373,6 +374,18 @@ public class RetryPolicy<R> extends DelayablePolicy<RetryPolicy<R>, R> {
     return withBackoff(delay, maxDelay, chronoUnit, 2);
   }
 
+  /* Backwards compatability for 1.x -> 2.x migration */
+  @Deprecated
+  public RetryPolicy<R> withBackoff(long delay, long maxDelay, TimeUnit timeUnit) {
+    return withBackoff(delay, maxDelay, TimeUnitToChronoUnit.toChronoUnit(timeUnit), 2);
+  }
+
+  /* Backwards compatability for 1.x -> 2.x migration */
+  @Deprecated
+  public RetryPolicy<R> withBackoff(long delay, long maxDelay, TimeUnit timeUnit, double delayFactor)  {
+    return withBackoff(delay, maxDelay, TimeUnitToChronoUnit.toChronoUnit(timeUnit), delayFactor);
+  }
+
   /**
    * Sets the {@code delay} between retries, exponentially backing off to the {@code maxDelay} and multiplying
    * successive delays by the {@code delayFactor}.
@@ -488,6 +501,12 @@ public class RetryPolicy<R> extends DelayablePolicy<RetryPolicy<R>, R> {
     return this;
   }
 
+  /* Backwards compatability for 1.x -> 2.x migration */
+  @Deprecated
+  public RetryPolicy<R> withJitter(long jitter, TimeUnit timeUnit) {
+    return withJitter(Duration.of(jitter, TimeUnitToChronoUnit.toChronoUnit(timeUnit)));
+  }
+
   /**
    * Sets the max number of execution attempts to perform. {@code -1} indicates no limit. This method has the same
    * effect as setting 1 more than {@link #withMaxRetries(int)}. For example, 2 retries equal 3 attempts.
@@ -513,6 +532,12 @@ public class RetryPolicy<R> extends DelayablePolicy<RetryPolicy<R>, R> {
     Assert.state(maxDuration.toNanos() > delay.toNanos(), "maxDuration must be greater than the delay");
     this.maxDuration = maxDuration;
     return this;
+  }
+
+  /* Backwards compatability for 1.x -> 2.x migration */
+  @Deprecated
+  public RetryPolicy<R> withMaxDuration(long maxDuration, TimeUnit timeUnit) {
+    return withMaxDuration(Duration.of(maxDuration, TimeUnitToChronoUnit.toChronoUnit(timeUnit)));
   }
 
   /**

--- a/src/main/java/net/jodah/failsafe/TimeUnitToChronoUnit.java
+++ b/src/main/java/net/jodah/failsafe/TimeUnitToChronoUnit.java
@@ -1,0 +1,27 @@
+package net.jodah.failsafe;
+
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
+
+public class TimeUnitToChronoUnit {
+  /**
+   * Converts this {@code TimeUnit} to the equivalent {@code ChronoUnit}.
+   *
+   * @return the converted equivalent ChronoUnit
+   * @since 9
+   */
+  /* Backwards compatability for 1.x -> 2.x migration */
+  @Deprecated
+  public static ChronoUnit toChronoUnit(TimeUnit timeUnit) {
+    switch (timeUnit) {
+      case NANOSECONDS:  return ChronoUnit.NANOS;
+      case MICROSECONDS: return ChronoUnit.MICROS;
+      case MILLISECONDS: return ChronoUnit.MILLIS;
+      case SECONDS:      return ChronoUnit.SECONDS;
+      case MINUTES:      return ChronoUnit.MINUTES;
+      case HOURS:        return ChronoUnit.HOURS;
+      case DAYS:         return ChronoUnit.DAYS;
+      default: throw new AssertionError();
+    }
+  }
+}

--- a/src/test/java/net/jodah/failsafe/RetryPolicyTest.java
+++ b/src/test/java/net/jodah/failsafe/RetryPolicyTest.java
@@ -149,7 +149,7 @@ public class RetryPolicyTest {
   }
 
   public void shouldRequireValidBackoff() {
-    shouldFail(() -> new RetryPolicy().withBackoff(0, 0, null), NullPointerException.class);
+    shouldFail(() -> new RetryPolicy().withBackoff(0, 0, (ChronoUnit) null), NullPointerException.class);
     shouldFail(
         () -> new RetryPolicy().withMaxDuration(Duration.ofMillis(1)).withBackoff(100, 120, ChronoUnit.MILLIS),
         IllegalStateException.class);


### PR DESCRIPTION
- Runtime compatibility of the `onOpen`, `onClosed`, and `onHalfOpen` callback hooks
- Provide backwards compatible support on `with` functions that migrated from `long, TimeUnit` to `Duration`
- Provide aliases for `failX` and `retryX` method formats, which the release notes state were migrated to the `handleX` method family
- Maintain a no-arg constructor for the `CircuitBreakerOpenException`

Based on `japi-check net.jodah:failsafe:1.0.3 net.jodah:failsafe:2.3.0`