### PR TITLE
Fix API issues from first attempted rollout

### DIFF
--- a/src/main/java/net/jodah/failsafe/CircuitBreaker.java
+++ b/src/main/java/net/jodah/failsafe/CircuitBreaker.java
@@ -17,6 +17,7 @@ package net.jodah.failsafe;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -266,26 +267,32 @@ public class CircuitBreaker<R> extends DelayablePolicy<CircuitBreaker<R>, R> {
 
   /* Backwards compatability for 1.x -> 2.x migration. Use `handle` */
   @Deprecated
-  public <T extends Throwable> CircuitBreaker failOn(Class<T> failure) {
+  public CircuitBreaker failOn(Class<? extends Throwable> failure) {
     return handle(failure);
   }
 
   /* Backwards compatability for 1.x -> 2.x migration. Use `handle` */
   @Deprecated
-  public final <T extends Throwable> CircuitBreaker failOn(Class<T>... failures) {
+  public CircuitBreaker failOn(Class<? extends Throwable>... failures) {
+    return handle(failures);
+  }
+
+  /* Backwards compatability for 1.x -> 2.x migration. Use `handle` */
+  @Deprecated
+  public CircuitBreaker failOn(List<Class<? extends Throwable>> failures) {
     return handle(failures);
   }
 
   /* Backwards compatability for 1.x -> 2.x migration. Use `handleIf` */
   @Deprecated
-  public <T extends Throwable> CircuitBreaker failOn(net.jodah.failsafe.function.Predicate<T> failurePredicate) {
+  public CircuitBreaker failOn(net.jodah.failsafe.function.Predicate<? extends Throwable> failurePredicate) {
     return handleIf(failurePredicate.toJavaUtil());
   }
 
   /* Backwards compatability for 1.x -> 2.x migration. Use `handleIf` */
   @Deprecated
-  public <T extends Throwable> CircuitBreaker failWhen(net.jodah.failsafe.function.Predicate<T> failurePredicate) {
-    return handleIf(failurePredicate.toJavaUtil());
+  public CircuitBreaker failWhen(R result) {
+    return handleIf(resultPredicateFor(result));
   }
 
   /* Backwards compatability for 1.x -> 2.x migration. Use `handleIf` */

--- a/src/main/java/net/jodah/failsafe/Failsafe.java
+++ b/src/main/java/net/jodah/failsafe/Failsafe.java
@@ -59,14 +59,14 @@ public class Failsafe {
 
   // Migrate to `withMigration` which will eventually migrate back to `with` to convert from 1.x `SyncFailsafe` to 2.x `FailsafeExecutor`
   @Deprecated
-  public static <R> SyncFailsafe<R> with(RetryPolicy<R> retryPolicy) {
-    return new SyncFailsafe<>(retryPolicy);
+  public static <R> SyncFailsafe<R> with(RetryPolicy retryPolicy) {
+    return new SyncFailsafe<R>(retryPolicy);
   }
 
   // Migrate to `withMigration` which will eventually migrate back to `with` to convert from 1.x `SyncFailsafe` to 2.x `FailsafeExecutor`
   @Deprecated
-  public static <R> SyncFailsafe<R> with(CircuitBreaker<R> circuitBreaker) {
-    return new SyncFailsafe<>(circuitBreaker);
+  public static <R> SyncFailsafe<R> with(CircuitBreaker circuitBreaker) {
+    return new SyncFailsafe<R>(circuitBreaker);
   }
 
   /**

--- a/src/main/java/net/jodah/failsafe/RetryPolicy.java
+++ b/src/main/java/net/jodah/failsafe/RetryPolicy.java
@@ -109,26 +109,32 @@ public class RetryPolicy<R> extends DelayablePolicy<RetryPolicy<R>, R> {
 
   /* Backwards compatability for 1.x -> 2.x migration. Use `handle` */
   @Deprecated
-  public <T extends Throwable> RetryPolicy retryOn(Class<T> failure) {
+  public RetryPolicy retryOn(Class<? extends Throwable> failure) {
     return handle(failure);
   }
 
   /* Backwards compatability for 1.x -> 2.x migration. Use `handle` */
   @Deprecated
-  public final <T extends Throwable> RetryPolicy retryOn(Class<T>... failures) {
+  public final RetryPolicy retryOn(Class<? extends Throwable>... failures) {
     return handle(failures);
   }
 
   /* Backwards compatability for 1.x -> 2.x migration. Use `handleIf` */
   @Deprecated
-  public final <T extends Throwable> RetryPolicy retryOn(net.jodah.failsafe.function.Predicate<T> failurePredicate) {
+  public final RetryPolicy retryOn(net.jodah.failsafe.function.Predicate<? extends Throwable> failurePredicate) {
     return handleIf(failurePredicate.toJavaUtil());
   }
 
   /* Backwards compatability for 1.x -> 2.x migration. Use `handleIf` */
   @Deprecated
-  public <T extends Throwable> RetryPolicy retryWhen(net.jodah.failsafe.function.Predicate<T> failurePredicate) {
-    return handleIf(failurePredicate.toJavaUtil());
+  public RetryPolicy retryOn(List<Class<? extends Throwable>> failures) {
+    return handle(failures);
+  }
+
+  /* Backwards compatability for 1.x -> 2.x migration. Use `handleIf` */
+  @Deprecated
+  public RetryPolicy retryWhen(R result) {
+    return handleIf(resultPredicateFor(result));
   }
 
   /* Backwards compatability for 1.x -> 2.x migration. Use `handleIf` */

--- a/src/test/java/net/jodah/failsafe/SyncFailsafeTest.java
+++ b/src/test/java/net/jodah/failsafe/SyncFailsafeTest.java
@@ -76,6 +76,12 @@ public class SyncFailsafeTest extends AbstractFailsafeTest {
     verify(service, times(3)).connect();
   }
 
+  // Using to assert usability of the old execution model during the migration. This usage was failing to conver from `Object` in the first attempted rollout
+  @Deprecated
+  public void shouldRunOldMethod() {
+    String x = Failsafe.with(new CircuitBreaker().withFailureThreshold(1)).get(() -> "testConversion");
+  }
+
   public void shouldRun() {
     assertRun((CheckedRunnable) () -> service.connect());
   }


### PR DESCRIPTION
The propagation of the generic type for the shim for `Failsafe.with` was incorrect and losing the type information. This should fix that and has a unit test to help show this.

The `retryOn` and `failOn` methods had an overload taking in a `List` that wasn't accounted for previously.